### PR TITLE
Update public endpoint of h2o/quicly

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ URLs to HTTP/3 test servers (usually) available. Most on draft h3-23 level.
 | [www.litespeedtech.com](https://www.litespeedtech.com) |       yes | lsquic        |
 | [nghttp2.org](https://nghttp2.org:4433/) |            no | ngtcp2        |
 | [test.privateoctopus.com](https://test.privateoctopus.com:4433/) |no | picoquic      |
-| [kazuhooku.com](https://kazuhooku.com:8443) |           no | quicly        |
+| [h2o.example.net](https://h2o.examp1e.net) |         yes | h2o/quicly    |
 | [quic.westus.cloudapp.azure.com](https://quic.westus.cloudapp.azure.com) |no| winquic       |
 
 Submit [updates as PRs](https://github.com/bagder/HTTP3-test/pulls)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ URLs to HTTP/3 test servers (usually) available. Most on draft h3-23 level.
 | [www.litespeedtech.com](https://www.litespeedtech.com) |       yes | lsquic        |
 | [nghttp2.org](https://nghttp2.org:4433/) |            no | ngtcp2        |
 | [test.privateoctopus.com](https://test.privateoctopus.com:4433/) |no | picoquic      |
-| [h2o.example.net](https://h2o.examp1e.net) |         yes | h2o/quicly    |
+| [h2o.examp1e.net](https://h2o.examp1e.net) |         yes | h2o/quicly    |
 | [quic.westus.cloudapp.azure.com](https://quic.westus.cloudapp.azure.com) |no| winquic       |
 
 Submit [updates as PRs](https://github.com/bagder/HTTP3-test/pulls)


### PR DESCRIPTION
Thank you for maintaining the list. H2O/quicly finally has a proper website serving H3.